### PR TITLE
feat: twitter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Discord bot to assist with the online StudentHack 2020.
 - Links Discord user accounts to HS accounts
 - Creates private text and voice channels for teams
 - Creates a private area for organisers and volunteers to communicate
+- Integration with twitter to fetch tweets about the event
 
 ## License
 

--- a/data/config.example.json
+++ b/data/config.example.json
@@ -9,5 +9,9 @@
     "hsAuth": {
         "url": "http://localhost:8000",
         "token": "Admin authorization token for HS services"
-    }
+    },
+	"twitter": {
+		"consumerKey": "string",
+		"consumerSecret": "string"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@unicsmcr/hs_auth_client": "^1.2.0",
     "discord-akairo": "^8.0.0",
     "discord.js": "^12.0.2",
+    "form-data": "^3.0.0",
     "node-fetch": "^2.6.0",
     "pino": "^5.17.0",
     "reflect-metadata": "^0.1.13",

--- a/src/HackathonClient.ts
+++ b/src/HackathonClient.ts
@@ -1,4 +1,4 @@
-import { AkairoClient, CommandHandler } from 'discord-akairo';
+import { AkairoClient, CommandHandler, ListenerHandler } from 'discord-akairo';
 import { ApplicationConfig } from './util/config-loader';
 import { join } from 'path';
 import { AuthClient } from './hs_auth/client';
@@ -27,6 +27,12 @@ export class HackathonClient extends AkairoClient {
 			allowMention: true,
 			directory: join(__dirname, 'commands')
 		});
+
+		const listenerHandler = new ListenerHandler(this, {
+			directory: join(__dirname, 'listeners')
+		});
+		this.commandHandler.useListenerHandler(listenerHandler);
+		listenerHandler.loadAll();
 
 		this.authClient = new AuthClient({
 			apiBase: config.hsAuth.url,

--- a/src/actions/setupGuild.ts
+++ b/src/actions/setupGuild.ts
@@ -121,6 +121,18 @@ export async function setupGuild(data: GuildSetupData) {
 		]
 	});
 
+	await guild.channels.create('twitter', {
+		type: 'text',
+		parent: hackathon.id,
+		topic: 'The #studenthack2020 Twitter feed!',
+		permissionOverwrites: [
+			{
+				id: guild.id,
+				deny: ['SEND_MESSAGES']
+			}
+		]
+	});
+
 	const social = await guild.channels.create('social', {
 		type: 'text',
 		parent: hackathon.id,

--- a/src/actions/setupGuild.ts
+++ b/src/actions/setupGuild.ts
@@ -67,6 +67,12 @@ export async function setupGuild(data: GuildSetupData) {
 		topic: 'A discussion channel for organisers and volunteers!'
 	});
 
+	await guild.channels.create('twitter-staging', {
+		type: 'text',
+		parent: staff.id,
+		topic: 'Where tweets get sent to be approved'
+	});
+
 	await guild.channels.create('Staff Voice Chat', {
 		type: 'voice',
 		parent: staff.id

--- a/src/commands/identify.ts
+++ b/src/commands/identify.ts
@@ -8,7 +8,7 @@ interface IdentifyCommandArgs {
 	id: string;
 }
 
-class IdentifyCommand extends Command {
+export default class IdentifyCommand extends Command {
 	public constructor() {
 		super('identify', {
 			aliases: ['identify', 'register'],
@@ -80,5 +80,3 @@ class IdentifyCommand extends Command {
 		}
 	}
 }
-
-module.exports = IdentifyCommand;

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js';
 import { Command } from 'discord-akairo';
 
-class PingCommand extends Command {
+export default class PingCommand extends Command {
 	public constructor() {
 		super('ping', {
 			aliases: ['ping']
@@ -13,4 +13,3 @@ class PingCommand extends Command {
 	}
 }
 
-module.exports = PingCommand;

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -4,7 +4,7 @@ import { resetGuild } from '../actions/resetGuild';
 import { HackathonClient } from '../HackathonClient';
 import { Task, TaskStatus } from '../util/task';
 
-class ResetCommand extends Command {
+export default class ResetCommand extends Command {
 	public constructor() {
 		super('reset', {
 			aliases: ['reset']
@@ -41,5 +41,3 @@ class ResetCommand extends Command {
 		}
 	}
 }
-
-module.exports = ResetCommand;

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -4,7 +4,7 @@ import { setupGuild } from '../actions/setupGuild';
 import { HackathonClient } from '../HackathonClient';
 import { Task, TaskStatus } from '../util/task';
 
-class SetupCommand extends Command {
+export default class SetupCommand extends Command {
 	public constructor() {
 		super('setup', {
 			aliases: ['setup']
@@ -42,5 +42,3 @@ class SetupCommand extends Command {
 		}
 	}
 }
-
-module.exports = SetupCommand;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ const logger = pino();
 const loggers = {
 	app: logger,
 	bot: logger.child({ name: 'bot' }),
-	db: logger.child({ name: 'db' })
+	db: logger.child({ name: 'db' }),
+	twitter: logger.child({ name: 'twitter' })
 };
 
 const client = new HackathonClient({ loggers, ...config });

--- a/src/listeners/reactionAdd.ts
+++ b/src/listeners/reactionAdd.ts
@@ -1,0 +1,70 @@
+import { Listener } from 'discord-akairo';
+import { HackathonClient } from '../HackathonClient';
+import { MessageReaction, User, TextChannel, MessageEmbed, Message } from 'discord.js';
+
+export default class ReactionAddListener extends Listener {
+	public constructor() {
+		super('messageReactionAdd', {
+			emitter: 'client',
+			event: 'messageReactionAdd'
+		});
+	}
+
+	public async approve(message: Message, user: User, targetChannel: TextChannel) {
+		const tweetURL = message.content;
+		const publicMessage = await targetChannel.send(message.content);
+		const embed = new MessageEmbed()
+			.setTitle('Tweet Approved')
+			.setAuthor(user.tag, user.displayAvatarURL())
+			.setDescription(`Approved tweet ${tweetURL}\n\n**[Jump to message](${publicMessage.url})**`)
+			.setColor('#a1ff9c')
+			.setTimestamp(new Date());
+		await message.edit(null, embed);
+		return tweetURL;
+	}
+
+	public async reject(message: Message, user: User) {
+		const tweetURL = message.content;
+		const embed = new MessageEmbed()
+			.setTitle('Tweet Rejected')
+			.setAuthor(user.tag, user.displayAvatarURL())
+			.setDescription(`Rejected tweet ${tweetURL}`)
+			.setColor('#ff9c9c')
+			.setTimestamp(new Date());
+		await message.edit(null, embed);
+		return tweetURL;
+	}
+
+	public async exec(reaction: MessageReaction, user: User) {
+		const client = user.client as HackathonClient;
+		const logger = client.config.loggers.twitter;
+		const channel = reaction.message.channel;
+		const tweetURL = reaction.message.content;
+
+		const shouldExec = channel.type === 'text' &&
+			channel.guild.id === client.config.discord.guildID &&
+			channel.name === 'twitter-staging' &&
+			['👍', '👎'].includes(reaction.emoji.name) &&
+			reaction.count === 1 &&
+			reaction.message.embeds.length > 0 &&
+			reaction.message.content.includes('https://twitter.com/');
+
+		if (shouldExec) {
+			const action = reaction.emoji.name === '👍' ? 'approve' : 'reject';
+			try {
+				const targetChannel = (channel as TextChannel).guild.channels.cache
+					.find(c => c.type === 'text' && c.name === 'twitter') as TextChannel | undefined;
+				if (!targetChannel) {
+					throw new Error('Could not find public twitter channel!');
+				}
+				action === 'approve'
+					? await this.approve(reaction.message, user, targetChannel)
+					: await this.reject(reaction.message, user);
+				logger.info(`Success: ${action} tweet ${tweetURL}`);
+			} catch (err) {
+				logger.warn(`Failed to ${action} tweet with message ID ${reaction.message.id}`);
+				logger.warn(err);
+			}
+		}
+	}
+}

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -3,7 +3,7 @@ import { TwitterStream, Tweet } from '../twitter';
 import { HackathonClient } from '../HackathonClient';
 import { TextChannel } from 'discord.js';
 
-export class ReadyListener extends Listener {
+export default class ReadyListener extends Listener {
 	private twitter?: TwitterStream;
 	private readonly started: Date;
 
@@ -29,17 +29,16 @@ export class ReadyListener extends Listener {
 				if (new Date(tweet.created_at) < this.started) return false;
 				const tweetURL = `https://twitter.com/${tweet.user.screen_name}/status/${tweet.id_str}`;
 				const guildID = client.config.discord.guildID;
-				const channel = client
-					.guilds.cache.get(guildID)
-					?.channels.cache.find(c => c.type === 'text' && c.name === 'twitter') as TextChannel | undefined;
+				const channel = client.guilds.cache.get(guildID)?.channels.cache
+					.find(c => c.type === 'text' && c.name === 'twitter-staging') as TextChannel | undefined;
 				if (!channel) {
-					logger.warn(`Tried to post ${tweetURL} in ${guildID}, couldn't find channel`);
+					logger.warn(`No staging channel for tweet ${tweetURL} in ${guildID}`);
 					return;
 				}
 				channel.send(tweetURL)
-					.then(() => logger.info(`Posted tweet ${tweetURL}`))
+					.then(() => logger.info(`Staged tweet ${tweetURL}`))
 					.catch(err => {
-						logger.warn(`Failed to post tweet ${tweetURL}:`);
+						logger.warn(`Failed to stage tweet ${tweetURL}:`);
 						logger.warn(err);
 					});
 			});
@@ -47,5 +46,3 @@ export class ReadyListener extends Listener {
 		console.log('I\'m ready!');
 	}
 }
-
-module.exports = ReadyListener;

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -1,0 +1,51 @@
+import { Listener } from 'discord-akairo';
+import { TwitterStream, Tweet } from '../twitter';
+import { HackathonClient } from '../HackathonClient';
+import { TextChannel } from 'discord.js';
+
+export class ReadyListener extends Listener {
+	private twitter?: TwitterStream;
+	private readonly started: Date;
+
+	public constructor() {
+		super('ready', {
+			emitter: 'client',
+			event: 'ready'
+		});
+		this.started = new Date();
+	}
+
+	public exec() {
+		const client = this.client as HackathonClient;
+		const logger = client.config.loggers.twitter;
+		if (!this.twitter) {
+			this.twitter = new TwitterStream({
+				...client.config.twitter,
+				search: { q: '#studenthack2020 OR @studenthack2020' },
+				interval: 5000,
+				logger
+			});
+			this.twitter.on('data', (tweet: Tweet) => {
+				if (new Date(tweet.created_at) < this.started) return false;
+				const guildID = client.config.discord.guildID;
+				const channel = client
+					.guilds.cache.get(guildID)
+					?.channels.cache.find(c => c.type === 'text' && c.name === 'twitter') as TextChannel | undefined;
+				if (!channel) {
+					logger.warn(`Tried to post ${tweet} in ${guildID}, couldn't find channel`);
+					return;
+				}
+				const tweetURL = `https://twitter.com/${tweet.user.screen_name}/status/${tweet.id_str}`;
+				channel.send(tweetURL)
+					.then(() => logger.info(`Posted tweet ${tweetURL}`))
+					.catch(err => {
+						logger.warn(`Failed to post tweet ${tweetURL}:`);
+						logger.warn(err);
+					});
+			});
+		}
+		console.log('I\'m ready!');
+	}
+}
+
+module.exports = ReadyListener;

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -27,15 +27,15 @@ export class ReadyListener extends Listener {
 			});
 			this.twitter.on('data', (tweet: Tweet) => {
 				if (new Date(tweet.created_at) < this.started) return false;
+				const tweetURL = `https://twitter.com/${tweet.user.screen_name}/status/${tweet.id_str}`;
 				const guildID = client.config.discord.guildID;
 				const channel = client
 					.guilds.cache.get(guildID)
 					?.channels.cache.find(c => c.type === 'text' && c.name === 'twitter') as TextChannel | undefined;
 				if (!channel) {
-					logger.warn(`Tried to post ${tweet} in ${guildID}, couldn't find channel`);
+					logger.warn(`Tried to post ${tweetURL} in ${guildID}, couldn't find channel`);
 					return;
 				}
-				const tweetURL = `https://twitter.com/${tweet.user.screen_name}/status/${tweet.id_str}`;
 				channel.send(tweetURL)
 					.then(() => logger.info(`Posted tweet ${tweetURL}`))
 					.catch(err => {

--- a/src/twitter/client.ts
+++ b/src/twitter/client.ts
@@ -17,8 +17,9 @@ interface SearchResponse {
 }
 
 // This is very minimally defined, only what we need for a Hackathon
-interface Tweet {
+export interface Tweet {
 	id_str: string;
+	created_at: string;
 	user: {
 		screen_name: string;
 	};
@@ -82,10 +83,6 @@ export class TwitterClient {
 				Authorization: `Bearer ${this.bearerToken}`
 			}
 		});
-		const data: SearchResponse = await apiResponse.json();
-		const tweets = data.statuses.map(
-			tweet => `https://twitter.com/${tweet.user.screen_name}/status/${tweet.id_str}`
-		);
-		return { tweets, maxTweet: data.search_metadata.max_id_str };
+		return await apiResponse.json() as SearchResponse;
 	}
 }

--- a/src/twitter/client.ts
+++ b/src/twitter/client.ts
@@ -1,0 +1,91 @@
+import fetch from 'node-fetch';
+import * as FormData from 'form-data';
+import { stringify, ParsedUrlQueryInput } from 'querystring';
+
+interface OAuth2Response {
+	token_type: string;
+	access_token: string;
+}
+
+// https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets
+interface SearchResponse {
+	statuses: Tweet[];
+	search_metadata: {
+		max_id_str: string;
+		refresh_url: string;
+	};
+}
+
+// This is very minimally defined, only what we need for a Hackathon
+interface Tweet {
+	id_str: string;
+	user: {
+		screen_name: string;
+	};
+}
+
+export interface TwitterClientConfig {
+	consumerKey: string;
+	consumerSecret: string;
+}
+
+export interface SearchOptions extends ParsedUrlQueryInput {
+	q: string;
+	geocode?: string;
+	lang?: string;
+	locale?: string;
+	result_type?: 'mixed' | 'recent' | 'popular';
+	count?: number;
+	until?: string;
+	since_id?: string;
+	max_id?: string;
+	include_entities?: string;
+}
+
+export class TwitterClient {
+	private readonly config: TwitterClientConfig;
+	private bearerToken?: string;
+
+	public constructor(config: TwitterClientConfig) {
+		this.config = config;
+	}
+
+	public async generateBearerToken() {
+		const body = new FormData();
+		body.append('grant_type', 'client_credentials');
+		const auth = Buffer.from(`${this.config.consumerKey}:${this.config.consumerSecret}`).toString('base64');
+		const apiResponse = await fetch('https://api.twitter.com/oauth2/token', {
+			method: 'POST',
+			headers: {
+				Authorization: `Basic ${auth}`
+			},
+			body
+		});
+		const data: OAuth2Response = await apiResponse.json();
+		if (data.token_type !== 'bearer' || !data.access_token) {
+			throw new Error(`Did not get a bearer token: ${JSON.stringify(data)}`);
+		}
+		this.bearerToken = data.access_token;
+		return data.access_token;
+	}
+
+	/**
+	 * Searches tweets matching the given options, and returns their URLs
+	 */
+	public async searchTweets(options: SearchOptions) {
+		if (!this.bearerToken) {
+			throw new Error('No bearer token! Try running client.generateBearerToken() first');
+		}
+		const apiResponse = await fetch(`https://api.twitter.com/1.1/search/tweets.json?${stringify(options)}`, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${this.bearerToken}`
+			}
+		});
+		const data: SearchResponse = await apiResponse.json();
+		const tweets = data.statuses.map(
+			tweet => `https://twitter.com/${tweet.user.screen_name}/status/${tweet.id_str}`
+		);
+		return { tweets, maxTweet: data.search_metadata.max_id_str };
+	}
+}

--- a/src/twitter/index.ts
+++ b/src/twitter/index.ts
@@ -1,0 +1,2 @@
+export { TwitterClient } from './client';
+export { TwitterStream } from './stream';

--- a/src/twitter/index.ts
+++ b/src/twitter/index.ts
@@ -1,2 +1,2 @@
-export { TwitterClient } from './client';
+export { TwitterClient, Tweet } from './client';
 export { TwitterStream } from './stream';

--- a/src/twitter/stream.ts
+++ b/src/twitter/stream.ts
@@ -1,0 +1,59 @@
+import { Readable } from 'stream';
+import { TwitterClient, TwitterClientConfig, SearchOptions } from './client';
+
+interface TwitterStreamConfig extends TwitterClientConfig, SearchOptions {
+	interval: number;
+}
+
+/**
+ * Periodically searches for new tweets matching the given filters.
+ * Pushes the URL for each tweet.
+ * @example
+ * // Checks for new tweets every 5 seconds that match the given query
+ * const stream = new TwitterStream({
+ *   consumerKey,
+ *   consumerSecret,
+ *   q: '#studenthack2020 OR @studenthack2020',
+ *   interval: 5000
+ * });
+ *
+ * stream.on('data', tweetURL => console.log(tweetURL));
+ */
+export class TwitterStream extends Readable {
+	private readonly client: TwitterClient;
+	private readonly config: TwitterStreamConfig;
+	private timeout?: NodeJS.Timeout;
+
+	public constructor(config: TwitterStreamConfig) {
+		super({ encoding: 'utf8', objectMode: true });
+		this.client = new TwitterClient(config);
+		this.config = config;
+	}
+
+	public async _read() {
+		if (this.timeout === undefined) {
+			await this.client.generateBearerToken();
+			this.fetch();
+		}
+	}
+
+	private async fetch(since?: string) {
+		const { tweets, maxTweet } = await this.client.searchTweets({
+			...this.config,
+			since_id: since || this.config.since_id
+		});
+		for (const tweet of tweets) {
+			if (!this.push(tweet)) {
+				return;
+			}
+		}
+		this.timeout = setTimeout(() => this.fetch(maxTweet), this.config.interval);
+	}
+
+	public _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
+		callback(error);
+	}
+}

--- a/src/util/config-loader.ts
+++ b/src/util/config-loader.ts
@@ -11,6 +11,10 @@ export interface HackathonConfig {
 		url: string;
 		token: string;
 	};
+	twitter: {
+		consumerKey: string;
+		consumerSecret: string;
+	};
 }
 
 export interface ApplicationConfig extends HackathonConfig {
@@ -18,6 +22,7 @@ export interface ApplicationConfig extends HackathonConfig {
 		app: Logger;
 		bot: Logger;
 		db: Logger;
+		twitter: Logger;
 	};
 }
 

--- a/src/util/task.ts
+++ b/src/util/task.ts
@@ -8,7 +8,7 @@ export enum TaskStatus {
 
 const TaskStatusColourMap = {
 	[TaskStatus.Active]: '#fffa9c',
-	[TaskStatus.Completed]: '#a1ff9c',
+	[TaskStatus.Completed]: '#ff9c9c',
 	[TaskStatus.Failed]: '#ff0000'
 };
 


### PR DESCRIPTION
Resolves #2

Users can create tweets under `#studenthack2020` and they will be captured by the Discord bot to be displayed in the Hackathon server.

**Checklist:**
- [x] Twitter API wrapper to get relevant tweets
- [x] Post to staging channel for staff to review
- [x] Approved tweets get posted to public channel

---

The implementation works like this:

- Bot creates a `twitter-staging` channel in the private area only visible to organisers and volunteers. Any relevant tweets are sent to this channel, where they must be manually approved by an organiser or volunteer before they are posted to the publicly available `twitter` channel.
- Bot will check every 5 seconds or so for new tweets mentioning #studenthack2020
- Tweets can be approved by a single organiser/volunteer reacting with the :+1: emoji. Similarly, they can be rejected with the :-1: emoji

**Example flow:**

1. The tweet is detected by the bot and posted to the staging channel. The organiser/volunteer gives it a :+1: reaction to approve it.
![image](https://user-images.githubusercontent.com/10330923/78032108-682a2780-735c-11ea-8b68-d3895570915f.png)

2. The tweet is approved, the message in the private channel is updated to reflect who approved the tweet. The tweet is then forwarded to the public twitter channel.
![image](https://user-images.githubusercontent.com/10330923/78032282-acb5c300-735c-11ea-97f4-d15b5b69083f.png)
![image](https://user-images.githubusercontent.com/10330923/78032319-ba6b4880-735c-11ea-9809-4bbde2a89165.png)
