### PR TITLE
Add extra commands

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [12.3.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,6 +950,11 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "humanize-duration": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.22.0.tgz",
+      "integrity": "sha512-kq2Ncl1E8I7LJtjWhraQS8/LCsdt6fTQ+fwrGJ8dLSNFITW5YQpGWAgPgzjfIErAID7QHv0PA+HZBPfAf6f7IA=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,9 +183,9 @@
       }
     },
     "@unicsmcr/hs_discord_bot_api_client": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@unicsmcr/hs_discord_bot_api_client/-/hs_discord_bot_api_client-0.0.2.tgz",
-      "integrity": "sha512-hLE0P/nx6e9O28eXuBlAt6nxRlYwb1AI+NMUlVX3wAfcDNrXn+ZhwsCCImotOVKlIkAz1fW4kciAU7MsHnG+3Q==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@unicsmcr/hs_discord_bot_api_client/-/hs_discord_bot_api_client-0.0.4.tgz",
+      "integrity": "sha512-UFHnFGpz5auQDj/Ubbh78EqrXUr67ys/HXxu7FadXQAJXl0i4iVmgw/JF25nu1rzv4iLPtzxOz5lM5PmGQKJPw==",
       "requires": {
         "axios": "^0.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
     "form-data": "^3.0.0",
+    "humanize-duration": "^3.22.0",
     "node-fetch": "^2.6.0",
     "pino": "^5.17.0"
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@types/node-fetch": "^2.5.5",
-    "@unicsmcr/hs_discord_bot_api_client": "^0.0.2",
+    "@unicsmcr/hs_discord_bot_api_client": "^0.0.4",
     "bad-words": "^3.0.3",
     "canvas": "^2.6.1",
     "discord-akairo": "^8.0.0",

--- a/src/HackathonClient.ts
+++ b/src/HackathonClient.ts
@@ -1,8 +1,9 @@
-import { AkairoClient, CommandHandler, ListenerHandler } from 'discord-akairo';
+import { AkairoClient, CommandHandler, ListenerHandler, Command } from 'discord-akairo';
 import { join } from 'path';
 import { Logger } from 'pino';
 import MuteTracker from './util/MuteTracker';
 import { Image } from 'canvas';
+import { Message } from 'discord.js';
 
 export interface ApplicationConfig {
 	discord: {
@@ -52,6 +53,10 @@ export class HackathonClient extends AkairoClient {
 			prefix: config.discord.prefix,
 			allowMention: true,
 			directory: join(__dirname, 'commands')
+		});
+
+		this.commandHandler.on('cooldown', (message: Message, command: Command, remaining: number) => {
+			message.reply(`You can't use that command for another ${Math.ceil(remaining / 1000)} seconds.`);
 		});
 
 		const listenerHandler = new ListenerHandler(this, {

--- a/src/HackathonClient.ts
+++ b/src/HackathonClient.ts
@@ -56,7 +56,9 @@ export class HackathonClient extends AkairoClient {
 		});
 
 		this.commandHandler.on('cooldown', (message: Message, command: Command, remaining: number) => {
-			message.reply(`You can't use that command for another ${Math.ceil(remaining / 1000)} seconds.`);
+			message
+				.reply(`You can't use that command for another ${Math.ceil(remaining / 1000)} seconds.`)
+				.catch(err => this.loggers.bot.warn(err));
 		});
 
 		const listenerHandler = new ListenerHandler(this, {

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -1,0 +1,31 @@
+import { Message, TextChannel, DMChannel, User } from 'discord.js';
+import { Command } from 'discord-akairo';
+import { Task, TaskStatus } from '../util/task';
+import { HackathonClient } from '../HackathonClient';
+
+export default class IdCommand extends Command {
+	public constructor() {
+		super('id', {
+			aliases: ['id'],
+			args: [
+				{
+					'id': 'target',
+					'type': 'user',
+					'default': (message: Message) => message.author
+				}
+			]
+		});
+	}
+
+	public async exec(message: Message, args: { target: User }) {
+		const task = new Task({
+			title: 'User ID',
+			issuer: message.author,
+			description: `${args.target.tag} - your ID is ${message.author.id}`,
+			status: TaskStatus.Completed
+		});
+		await task.sendTo(message.channel as TextChannel | DMChannel).catch(error => {
+			(this.client as HackathonClient).config.loggers.bot.warn(error);
+		});
+	}
+}

--- a/src/commands/mentor.ts
+++ b/src/commands/mentor.ts
@@ -32,7 +32,6 @@ export default class MentorCommand extends Command {
 			args: [
 				{
 					id: 'roles',
-					type: 'lowercase',
 					match: 'content'
 				}
 			],
@@ -42,19 +41,21 @@ export default class MentorCommand extends Command {
 
 	public async exec(message: Message, args: { roles: string }) {
 		const task = new Task({
-			title: 'Update Mentor Roles',
+			title: 'Update Mentor Roles (local)',
 			issuer: message.author,
 			description: 'Updating your mentoring status...'
 		});
 		await task.sendTo(message.channel as TextChannel | DMChannel);
 
-		const roles = args.roles.split(' ');
+		const roles = (args.roles?.toLowerCase() || '').split(' ');
+		console.log('HELLO', roles);
 		const langRoles = [];
 		for (const [roleName, resourceName] of Object.entries(MentorMappings)) {
 			if (roles.includes(roleName)) {
 				langRoles.push(resourceName);
 			}
 		}
+		console.log('BOP', langRoles);
 		try {
 			const user = await getUser(message.author.id);
 			if (user.authLevel < AuthLevel.Volunteer) {

--- a/src/commands/mentor.ts
+++ b/src/commands/mentor.ts
@@ -32,30 +32,29 @@ export default class MentorCommand extends Command {
 			args: [
 				{
 					id: 'roles',
-					match: 'content'
+					match: 'separate',
+					type: 'lowercase'
 				}
 			],
 			channel: 'guild'
 		});
 	}
 
-	public async exec(message: Message, args: { roles: string }) {
+	public async exec(message: Message, args: { roles: string[] }) {
 		const task = new Task({
-			title: 'Update Mentor Roles (local)',
+			title: 'Update Mentor Roles (local2)',
 			issuer: message.author,
 			description: 'Updating your mentoring status...'
 		});
 		await task.sendTo(message.channel as TextChannel | DMChannel);
 
-		const roles = (args.roles?.toLowerCase() || '').split(' ');
-		console.log('HELLO', roles);
+		const roles = args.roles;
 		const langRoles = [];
 		for (const [roleName, resourceName] of Object.entries(MentorMappings)) {
 			if (roles.includes(roleName)) {
 				langRoles.push(resourceName);
 			}
 		}
-		console.log('BOP', langRoles);
 		try {
 			const user = await getUser(message.author.id);
 			if (user.authLevel < AuthLevel.Volunteer) {
@@ -73,7 +72,7 @@ export default class MentorCommand extends Command {
 				roles: existingRoles.concat(langRoles)
 			});
 
-			task.update({
+			await task.update({
 				status: TaskStatus.Completed,
 				description: 'Your new mentor roles have been set!'
 			});

--- a/src/commands/mentor.ts
+++ b/src/commands/mentor.ts
@@ -48,7 +48,7 @@ export default class MentorCommand extends Command {
 		});
 		await task.sendTo(message.channel as TextChannel | DMChannel);
 
-		const roles = args.roles;
+		const roles = args.roles || [];
 		const langRoles = [];
 		for (const [roleName, resourceName] of Object.entries(MentorMappings)) {
 			if (roles.includes(roleName)) {

--- a/src/commands/mentor.ts
+++ b/src/commands/mentor.ts
@@ -2,6 +2,7 @@ import { Message, TextChannel, DMChannel } from 'discord.js';
 import { Command } from 'discord-akairo';
 import { modifyUserRoles, getUser, AuthLevel } from '@unicsmcr/hs_discord_bot_api_client';
 import { Task, TaskStatus } from '../util/task';
+import { HackathonClient } from '../HackathonClient';
 
 const MentorMappings = {
 	'python': 'role.languages.python',
@@ -41,8 +42,9 @@ export default class MentorCommand extends Command {
 	}
 
 	public async exec(message: Message, args: { roles: string[] }) {
+		const client = this.client as HackathonClient;
 		const task = new Task({
-			title: 'Update Mentor Roles (local2)',
+			title: 'Update Mentor Roles',
 			issuer: message.author,
 			description: 'Updating your mentoring status...'
 		});
@@ -77,6 +79,7 @@ export default class MentorCommand extends Command {
 				description: 'Your new mentor roles have been set!'
 			});
 		} catch (err) {
+			client.loggers.bot.warn(err);
 			task.update({
 				status: TaskStatus.Failed,
 				description: `An error occurred processing your request. Please try again later.`

--- a/src/commands/mute.ts
+++ b/src/commands/mute.ts
@@ -61,6 +61,7 @@ export default class MuteCommand extends Command {
 				description: `Muted **${args.target.user.tag}** (${args.target.id})`
 			});
 		} catch (err) {
+			client.loggers.bot.warn(err);
 			task.update({
 				status: TaskStatus.Failed,
 				description: `An error occurred processing your request. Please try again later.`

--- a/src/commands/mute.ts
+++ b/src/commands/mute.ts
@@ -14,8 +14,7 @@ export default class MuteCommand extends Command {
 					type: 'member',
 					prompt: {
 						start: 'Who would you like to mute?',
-						retry: 'That\'s not a valid member! Try again.',
-						optional: true
+						retry: 'That\'s not a valid member! Try again.'
 					}
 				}
 			],

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -48,11 +48,11 @@ export default class StatsCommand extends Command {
 			);
 			task.update({});
 		} catch (error) {
+			client.loggers.bot.warn(error);
 			task.update({
 				status: TaskStatus.Failed,
 				description: `An error occurred processing your request. Please try again later.`
 			});
-			console.log(error);
 		}
 	}
 }

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -2,7 +2,7 @@ import { Message, TextChannel, DMChannel } from 'discord.js';
 import { Command } from 'discord-akairo';
 import { Task, TaskStatus } from '../util/task';
 import { HackathonClient } from '../HackathonClient';
-import { getTeams, getUsers } from '@unicsmcr/hs_discord_bot_api_client';
+import { getTeams, getUsers, AuthLevel } from '@unicsmcr/hs_discord_bot_api_client';
 import humanizeDuration from 'humanize-duration';
 
 export default class StatsCommand extends Command {
@@ -32,10 +32,16 @@ export default class StatsCommand extends Command {
 			task.status = TaskStatus.Completed;
 			task.description = '';
 			const [users, teams] = await Promise.all([getUsers(), getTeams()]);
+			const participants = users.filter(user => user.authLevel === AuthLevel.Attendee).length;
+			const volunteers = users.filter(user => user.authLevel === AuthLevel.Volunteer).length;
 			task.addFields(
 				{
 					name: 'Participants in Discord server',
-					value: users.length
+					value: participants
+				},
+				{
+					name: 'Volunteers in Discord server',
+					value: volunteers
 				},
 				{
 					name: 'Teams',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -3,6 +3,7 @@ import { Command } from 'discord-akairo';
 import { Task, TaskStatus } from '../util/task';
 import { HackathonClient } from '../HackathonClient';
 import { getTeams, getUsers } from '@unicsmcr/hs_discord_bot_api_client';
+import humanizeDuration from 'humanize-duration';
 
 export default class StatsCommand extends Command {
 	public constructor() {
@@ -39,6 +40,10 @@ export default class StatsCommand extends Command {
 				{
 					name: 'Teams',
 					value: teams.length
+				},
+				{
+					name: 'Uptime',
+					value: client.uptime ? humanizeDuration(client.uptime) : 'Undefined'
 				}
 			);
 			task.update({});

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -13,7 +13,10 @@ export default class SyncCommand extends Command {
 					'type': 'user',
 					'default': (message: Message) => message.author
 				}
-			]
+			],
+			// One use per minute to stop abuse of API
+			cooldown: 60e3,
+			ratelimit: 1
 		});
 	}
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,40 @@
+import { Message, TextChannel, DMChannel, User } from 'discord.js';
+import { Command } from 'discord-akairo';
+import { Task, TaskStatus } from '../util/task';
+import { syncAccount } from '@unicsmcr/hs_discord_bot_api_client';
+
+export default class SyncCommand extends Command {
+	public constructor() {
+		super('sync', {
+			aliases: ['sync'],
+			args: [
+				{
+					'id': 'target',
+					'type': 'user',
+					'default': (message: Message) => message.author
+				}
+			]
+		});
+	}
+
+	public async exec(message: Message, args: { target: User }) {
+		const task = new Task({
+			title: 'User sync',
+			issuer: message.author,
+			description: `Syncing state for ${args.target.tag}`
+		});
+		await task.sendTo(message.channel as TextChannel | DMChannel);
+		try {
+			await syncAccount(args.target.id);
+			await task.update({
+				status: TaskStatus.Completed,
+				description: `Synced state for ${args.target.tag}!`
+			});
+		} catch (error) {
+			await task.update({
+				status: TaskStatus.Failed,
+				description: `An error occurred processing your request. Try again later.\n\n${error.message}`
+			});
+		}
+	}
+}

--- a/src/commands/unmute.ts
+++ b/src/commands/unmute.ts
@@ -14,8 +14,7 @@ export default class MuteCommand extends Command {
 					type: 'member',
 					prompt: {
 						start: 'Who would you like to unmute?',
-						retry: 'That\'s not a valid member! Try again.',
-						optional: true
+						retry: 'That\'s not a valid member! Try again.'
 					}
 				}
 			],

--- a/src/commands/unmute.ts
+++ b/src/commands/unmute.ts
@@ -63,6 +63,7 @@ export default class MuteCommand extends Command {
 				description: `Unmuted **${args.target.user.tag}** (${args.target.id})`
 			});
 		} catch (err) {
+			client.loggers.bot.warn(err);
 			task.update({
 				status: TaskStatus.Failed,
 				description: `An error occurred processing your request. Please try again later.`

--- a/src/commands/whois.ts
+++ b/src/commands/whois.ts
@@ -1,0 +1,106 @@
+import { Message, TextChannel, DMChannel, User } from 'discord.js';
+import { Command } from 'discord-akairo';
+import { Task, TaskStatus } from '../util/task';
+import { getUser, getTeam, APITeam, AuthLevel } from '@unicsmcr/hs_discord_bot_api_client';
+import { HackathonClient } from '../HackathonClient';
+
+export default class WhoIsCommand extends Command {
+	public constructor() {
+		super('whois', {
+			aliases: ['whois'],
+			args: [
+				{
+					id: 'target',
+					type: 'user',
+					prompt: {
+						start: 'Who would you like to get the details of?',
+						retry: 'That\'s not a valid member! Try again.'
+					}
+				}
+			]
+		});
+	}
+
+	public async exec(message: Message, args: { target: User }) {
+		const client = this.client as HackathonClient;
+		const task = new Task({
+			title: 'User info',
+			issuer: message.author,
+			description: 'Fetching the info now...'
+		});
+		await task.sendTo(message.channel as TextChannel | DMChannel);
+		try {
+			const issuer = await getUser(message.author.id);
+			if (issuer.authLevel < AuthLevel.Volunteer) {
+				return task.update({
+					status: TaskStatus.Failed,
+					description: 'Sorry, you need to be a volunteer or organiser to use this command.'
+				});
+			}
+
+			if (message.guild) {
+				const channel = message.channel as TextChannel;
+				if (channel.permissionsFor(message.guild.id)?.has('VIEW_CHANNEL')) {
+					return task.update({
+						status: TaskStatus.Failed,
+						description: 'Sorry, you need to run this in a private channel.'
+					});
+				}
+			}
+
+			task.status = TaskStatus.Completed;
+			task.description = '';
+			const user = await getUser(args.target.id);
+			task.addFields(
+				{
+					name: 'Name',
+					value: user.name
+				},
+				{
+					name: 'Auth ID',
+					value: user.authId
+				}
+			);
+			let team: APITeam | undefined;
+			if (user.team) {
+				try {
+					team = await getTeam(user.team);
+					task.addFields(
+						{
+							name: 'Team Name',
+							value: team.name
+						},
+						{
+							name: 'Team Auth ID',
+							value: team.authId
+						},
+						{
+							name: 'Team Number',
+							value: team.teamNumber
+						}
+					);
+				} catch (error) {
+					task.addFields({
+						name: 'Team',
+						value: `Auth ID: ${user.team} (error fetching more info than this)`
+					});
+					client.config.loggers.bot.warn(`Error fetching team ${user.team}`);
+					client.config.loggers.bot.warn(error);
+				}
+			}
+			task.update({});
+		} catch (error) {
+			if (error.res?.statusCode === 404) {
+				task.update({
+					status: TaskStatus.Failed,
+					description: `This account is not linked.`
+				});
+			} else {
+				task.update({
+					status: TaskStatus.Failed,
+					description: `An error occurred processing your request. Try again later.`
+				});
+			}
+		}
+	}
+}

--- a/src/types/humanize-duration.d.ts
+++ b/src/types/humanize-duration.d.ts
@@ -1,0 +1,3 @@
+declare module 'humanize-duration' {
+	export default function humanizeDuration(duration: number): string;
+}


### PR DESCRIPTION
This PR adds the extra commands used during SH8.

This locks the CI to an earlier Node.js version as one of `node-canvas`'s nested dependencies (`needle`) is breaking the installation of prebuilts (https://github.com/Automattic/node-canvas/issues/1587). `needle` is now updated, but until `node-canvas` depends on `node-pre-gyp@0.12.0` then the CI should stay locked here. 