### PR TITLE
feat: workshop attendee tracking

### DIFF
--- a/src/commands/listeners.ts
+++ b/src/commands/listeners.ts
@@ -68,11 +68,6 @@ export default class ListenersCommand extends Command {
 				csv.push(record.map(v => escape(v)).join(','));
 			}
 
-			await task.update({
-				status: TaskStatus.Completed,
-				description: `Got the list of users in ${args.target.name}!`
-			});
-
 			await message.author.send('', {
 				files: [
 					{
@@ -80,6 +75,11 @@ export default class ListenersCommand extends Command {
 						name: 'listeners.csv'
 					}
 				]
+			});
+
+			await task.update({
+				status: TaskStatus.Completed,
+				description: `Sent list of users in ${args.target.name}!`
 			});
 		} catch (err) {
 			client.loggers.bot.warn(err);

--- a/src/commands/listeners.ts
+++ b/src/commands/listeners.ts
@@ -46,16 +46,6 @@ export default class ListenersCommand extends Command {
 				});
 			}
 
-			if (message.guild) {
-				const channel = message.channel as TextChannel;
-				if (channel.permissionsFor(message.guild.id)?.has('VIEW_CHANNEL')) {
-					return task.update({
-						status: TaskStatus.Failed,
-						description: 'Sorry, you need to run this in a private channel.'
-					});
-				}
-			}
-
 			const _users = await getUsers();
 			const users: Record<string, APIUser> = {};
 			for (const user of _users) {
@@ -83,7 +73,7 @@ export default class ListenersCommand extends Command {
 				description: `Got the list of users in ${args.target.name}!`
 			});
 
-			await message.channel.send('', {
+			await message.author.send('', {
 				files: [
 					{
 						attachment: Buffer.from(csv.join('\n')),

--- a/src/commands/listeners.ts
+++ b/src/commands/listeners.ts
@@ -1,0 +1,73 @@
+import { Message, TextChannel, DMChannel, VoiceChannel } from 'discord.js';
+import { Command } from 'discord-akairo';
+import { Task, TaskStatus } from '../util/task';
+import { HackathonClient } from '../HackathonClient';
+
+export default class ListenersCommand extends Command {
+	public constructor() {
+		super('listeners', {
+			aliases: ['listeners'],
+			args: [
+				{
+					id: 'target',
+					type: 'voiceChannel',
+					prompt: {
+						start: 'Which channel (provide the channel ID)?',
+						retry: 'That\'s not a valid channel! Try again.'
+					}
+				}
+			],
+			channel: 'guild'
+		});
+	}
+
+	public async exec(message: Message, args: { target: VoiceChannel }) {
+		const client = message.client as HackathonClient;
+
+		const task = new Task({
+			title: 'Listeners',
+			issuer: message.author,
+			description: `Getting the list of users in ${args.target.name}...`
+		});
+		await task.sendTo(message.channel as TextChannel | DMChannel);
+
+		try {
+			if (!(await client.discordUserCanAccessResource(message.author.id, 'hs:hs_discord:bot:listeners'))) {
+				return task.update({
+					status: TaskStatus.Failed,
+					description: 'Sorry, you do not have permission to use this command.'
+				});
+			}
+
+			if (message.guild) {
+				const channel = message.channel as TextChannel;
+				if (channel.permissionsFor(message.guild.id)?.has('VIEW_CHANNEL')) {
+					return task.update({
+						status: TaskStatus.Failed,
+						description: 'Sorry, you need to run this in a private channel.'
+					});
+				}
+			}
+
+			const users = args.target.members.map(member => member.id);
+
+			await task.update({
+				status: TaskStatus.Completed,
+				description: `Got the list of users in ${args.target.name}!`
+			});
+
+			await task.attachFiles([
+				{
+					attachment: Buffer.from(JSON.stringify(users)),
+					name: 'listeners.csv'
+				}
+			]);
+		} catch (err) {
+			client.loggers.bot.warn(err);
+			task.update({
+				status: TaskStatus.Failed,
+				description: `An error occurred processing your request. Please try again later.`
+			}).catch(err => client.loggers.bot.warn(err));
+		}
+	}
+}

--- a/src/commands/listeners.ts
+++ b/src/commands/listeners.ts
@@ -86,7 +86,7 @@ export default class ListenersCommand extends Command {
 			await message.channel.send('', {
 				files: [
 					{
-						attachment: Buffer.from(csv.join(',')),
+						attachment: Buffer.from(csv.join('\n')),
 						name: 'listeners.csv'
 					}
 				]


### PR DESCRIPTION
Adds the `!listeners <channel>` command to get the listeners in a voice channel (i.e. the workshop attendees).

Requires the `hs:hs_discord:bot:listeners` resource URI on the auth system. Can only be run in private channels (i.e. organiser channels) as it contains personal data.

---

![image](https://user-images.githubusercontent.com/10330923/100394323-a2a3ab80-3034-11eb-9d3f-d1307ed7ea26.png)

The CSV file contains the following information for each user in the voice channel:

- Their real name (as taken from the auth system)
- Their sign-up email address
- Their discord tag
- Their IDs on the auth system and Discord